### PR TITLE
Fixed Switch 2 support

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,6 +19,7 @@ Please use the following form when submitting a pull request for amiibo database
 {
 	"games3DS": [],
 	"gamesWiiU": [],
-	"gamesSwitch": []
+	"gamesSwitch": [],
+	"gamesSwitch2": []
 }
 ```

--- a/amiibo/amiibo.py
+++ b/amiibo/amiibo.py
@@ -130,7 +130,7 @@ class UnknownMask(Hex):
 
 
 class Amiibo:
-    def __init__(self, manager, head, tail, name, release, games3DS, gamesWiiU, gamesSwitch):
+    def __init__(self, manager, head, tail, name, release, games3DS, gamesWiiU, gamesSwitch, gamesSwitch2):
         self.manager = manager
         self.head = Hex(head)
         self.tail = Hex(tail)
@@ -139,6 +139,7 @@ class Amiibo:
         self.games3DS = games3DS
         self.gamesWiiU = gamesWiiU
         self.gamesSwitch = gamesSwitch
+        self.gamesSwitch2 = gamesSwitch2
 
     @cached_property
     def id(self):

--- a/amiibo/filterable.py
+++ b/amiibo/filterable.py
@@ -160,6 +160,10 @@ class AmiiboCollection(FilterableCollection):
         value = value.lower() if value else value
         return lambda x: value in x.game_series.name.lower()
 
+    @filterable('switch2_titleid')
+    def filter_switch2_titleid(self, value):
+        return lambda x: any(value in game.get("gameID") for game in x.gamesSwitch2)
+    
     @filterable('switch_titleid')
     def filter_switch_titleid(self, value):
         return lambda x: any(value in game.get("gameID") for game in x.gamesSwitch)

--- a/amiibo/manager.py
+++ b/amiibo/manager.py
@@ -46,6 +46,7 @@ class AmiiboManager:
                     'games3DS': amiibo.games3DS,
                     'gamesWiiU': amiibo.gamesWiiU,
                     'gamesSwitch': amiibo.gamesSwitch
+                    'gamesSwitch2': amiibo.gamesSwitch2
                 }
                 for amiibo in self.amiibosfull
             },
@@ -83,7 +84,7 @@ class AmiiboManager:
                         jp=AmiiboManager._parse_date(amiibo['release']['jp']),
                         eu=AmiiboManager._parse_date(amiibo['release']['eu']),
                         au=AmiiboManager._parse_date(amiibo['release']['au']),
-                ), data1['amiibos'][id_]['games3DS'], data1['amiibos'][id_]['gamesWiiU'], data1['amiibos'][id_]['gamesSwitch'])
+                ), data1['amiibos'][id_]['games3DS'], data1['amiibos'][id_]['gamesWiiU'], data1['amiibos'][id_]['gamesSwitch'], data1['amiibos'][id_]['gamesSwitch2'])
                 for id_, amiibo in data['amiibos'].items()
         )
 
@@ -93,10 +94,16 @@ class AmiiboManager:
                         jp=AmiiboManager._parse_date(amiibo['release']['jp']),
                         eu=AmiiboManager._parse_date(amiibo['release']['eu']),
                         au=AmiiboManager._parse_date(amiibo['release']['au']),
-                ), data1['amiibos'][id_]['games3DS'], data1['amiibos'][id_]['gamesWiiU'], data1['amiibos'][id_]['gamesSwitch'])
+                ), data1['amiibos'][id_]['games3DS'], data1['amiibos'][id_]['gamesWiiU'], data1['amiibos'][id_]['gamesSwitch'], data1['amiibos'][id_]['gamesSwitch2'])
                 for id_, amiibo in data['amiibos'].items()
         )
         for amiibo in self.amiibosfullwithoutusage:
+            amiibo.gamesSwitch2 = copy.deepcopy(amiibo.gamesSwitch2)
+            for game in amiibo.gamesSwitch2:
+                try:
+                    del game['amiiboUsage']
+                except:
+                    pass
             amiibo.gamesSwitch = copy.deepcopy(amiibo.gamesSwitch)
             for game in amiibo.gamesSwitch:
                 try:
@@ -128,6 +135,7 @@ class AmiiboManager:
         )
         for amiibo in self.amiibos:
             try:
+                del amiibo.gamesSwitch2
                 del amiibo.gamesSwitch
                 del amiibo.games3DS
                 del amiibo.gamesWiiU

--- a/commons/amiibo_json_encounter.py
+++ b/commons/amiibo_json_encounter.py
@@ -30,7 +30,7 @@ class AmiiboJSONEncoder(JSONEncoder):
                 'release': obj.release
             }
             try:
-                returner.update({'games3DS': obj.games3DS, 'gamesWiiU': obj.gamesWiiU, 'gamesSwitch': obj.gamesSwitch})
+                returner.update({'games3DS': obj.games3DS, 'gamesWiiU': obj.gamesWiiU, 'gamesSwitch': obj.gamesSwitch, 'gamesSwitch2': obj.gamesSwitch2})
             except AttributeError:
                 pass
             return returner

--- a/routes/amiibofull.py
+++ b/routes/amiibofull.py
@@ -103,6 +103,7 @@ def route_api_amiibofull():
                 'gameseries': 'gameseries',
                 'gameseries_id': 'game_series_id',
                 'gameseries_name': 'game_series_name',
+                'switch2_titleid' : 'gamesSwitch2',
                 'switch_titleid' : 'gamesSwitch',
                 '3ds_titleid' : 'games3DS',
                 'wiiu_titleid' : 'gamesWiiU',


### PR DESCRIPTION
The https://amiiboapi.org/api/amiibo/?showusage endpoint wasn't populated with Nintendo Switch 2 games.

Upon closer inspection it seems that there were some places support for Switch 2 was forgotten, this PR should resolve that and ensure Switch 2 games will show up in usage information. 

Updated the PR template as well for good measure.