### PR TITLE
Fix Flask 3 boot crash by porting the JSON encoder to the provider API

### DIFF
--- a/app.py
+++ b/app.py
@@ -36,7 +36,7 @@ app.register_blueprint(amiiboApp)
 app.register_blueprint(amiibofullApp)
 
 CORS(app)
-app.json_encoder = AmiiboJSONEncoder
+app.json = AmiiboJSONEncoder(app)
 Compress(app)
 
 amiibo_manager = AmiiboManager.getInstance()

--- a/commons/amiibo_json_encounter.py
+++ b/commons/amiibo_json_encounter.py
@@ -1,6 +1,6 @@
 import datetime
 
-from flask.json import JSONEncoder
+from flask.json.provider import DefaultJSONProvider
 
 from amiibo.amiibo import (Amiibo,
                            AmiiboReleaseDates,
@@ -11,7 +11,7 @@ from amiibo.amiibo import (Amiibo,
                            Hex)
 from amiibo.filterable import FilterableCollection
 
-class AmiiboJSONEncoder(JSONEncoder):
+class AmiiboJSONEncoder(DefaultJSONProvider):
     def default(self, obj):
         if isinstance(obj, Hex):
             return str(obj)


### PR DESCRIPTION
When #6 bumped Flask to 3.1.3 the app stopped booting, and #22 pinned things back to Flask 2.2.5 + Werkzeug 2.3.8 to get workers up again. The actual root cause is that flask.json.JSONEncoder and app.json_encoder were removed in newer Flask, so importing AmiiboJSONEncoder crashes every gunicorn worker on boot.

This ports the encoder to the JSON provider API instead:

- AmiiboJSONEncoder now subclasses flask.json.provider.DefaultJSONProvider, with the same default() logic and unchanged output
- registered with app.json = AmiiboJSONEncoder(app) instead of app.json_encoder

The provider API has been around since Flask 2.2, so nothing changes on the currently pinned 2.2.5. It just makes a Flask 3 upgrade possible again whenever you want it. That also matters for newer Python, since Flask 2.2.5 does not run on 3.14 at all (pkgutil.get_loader is gone).

I have been running this self-hosted on Flask 3.1 / Python 3.14 with gunicorn and the full database serves fine, including the custom encoded fields (hex IDs, release dates, collections).